### PR TITLE
A3: add shared VirtualBox folder and hostPath volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,53 @@ Then open `http://sms.local/` to reach the frontend; it talks to `model-service`
 ### Minikube note
 If using Minikube, enable ingress and get an IP via `minikube addons enable ingress` and `minikube tunnel`, add that IP to `/etc/hosts` for `sms.local`, and browse the same URL.
 
+## Using a Shared VirtualBox Folder to Create Shared Storage Across All Pods
+All VMs mount the same shared VirtualBox folder as `/mnt/shared` into the VM.
+The deployed application mounts this path as a `hostPath` Volume into at least one `Deployment` (In our case this deployment is `app-deployment.yaml`; specifically, the stable version of the app).
+
+In order to prove this functionality, we have `a3-kubernetes-proof.txt` file in the `shared` directory. 
+
+According to the official Kubernetes documentation, "if you allow a read-write mount of any host path by an untrusted Pod, the containers in that Pod may be able to subvert the read-write host mount." Therefore, in order to avoid any possible issues that may arrive, any mounts of `hostPath` volume are "read only." 
+
+To verify shared storage, read the file from /mnt/shared on two different VMs (the controller and a worker):
+```bash
+ssh vagrant@192.168.56.100 "cat /mnt/shared/a3-kubernetes-proof.txt"
+ssh vagrant@192.168.56.101 "cat /mnt/shared/a3-kubernetes-proof.txt"
+```
+
+You should see:
+
+If you are seeing this message inside a pod, shared storage is working correctly! 
+
+
+If you are seeing this message inside a pod, shared storage is working correctly! 
+
+
+
+This shows that `/mnt/shared` exists on both VMs, and its contents are identical. 
+
+Afterwards, verify inside the Kubernetes pod, since we implemented this functionality for the stable version of app, do: 
+
+```bash
+KUBECONFIG=./kubeconfig kubectl get pods -n default | grep app-stable
+```
+
+pick one of the running pods, replace `<copy-your-pod-name-here>`with your actual pod name, and run : `cat /mnt/shared/a3-kubernetes-proof.txt` in that specific container. 
+
+```bash
+KUBECONFIG=./kubeconfig kubectl exec -n default -it <copy-your-pod-name-here> -- cat /mnt/shared/a3-kubernetes-proof.txt
+```
+
+You should see: 
+
+If you are seeing this message inside a pod, shared storage is working correctly! 
+
+
+
+This means that this pod can successfully see `/mnt/shared`. Pod mount is working. 
+
+
+
 ## Prometheus Monitoring
 
 The Helm chart includes kube-prometheus-stack which installs:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,6 +65,36 @@ Vagrant.configure("2") do |config|
     end
   end
 
+
+  #----------------------------------------------------------
+  # Synced-folders
+  #----------------------------------------------------------
+
+  # the first parameter is a path to a directory on the host machine.
+  # in the case that the path is relative, it is relative to the project root
+  # the second parameter must be an absolute path of where to share the folder 
+  # within the guest machine. 
+  # this folder will be created (recursively, if it must) if it does not exist.
+  # By default, vagrant mounts the synced folders with the owner/group set 
+  # to the SSH user and any parent folders set to root
+  # create: if true, the host path will be created if 
+  # it does not exist. Defaults to false
+  # owner: the user who should be the owner of this synced folder. 
+  # by default this will be the SSH user. 
+  # group: the group that will own the synced folder. 
+  # by default this will bbe the SSH user. 
+  # optionally you can use "root" but not needed
+  # mount_options: a list of additional mount options to pass 
+  # to the mount command
+
+  config.vm.synced_folder "./shared", "/mnt/shared",
+    create: true,
+    owner: "vagrant", 
+    group: "vagrant"
+    # mount_options: []
+
+
+
   #----------------------------------------------------------
   # Generate inventory.cfg automatically
   #----------------------------------------------------------

--- a/shared/a3-kubernetes-proof.txt
+++ b/shared/a3-kubernetes-proof.txt
@@ -1,0 +1,3 @@
+If you are seeing this message inside a pod, shared storage is working correctly! 
+
+

--- a/sms-checker-helm-chart/templates/app-deployment.yaml
+++ b/sms-checker-helm-chart/templates/app-deployment.yaml
@@ -67,6 +67,20 @@ spec:
                   key: PASSWORD
             - name: APP_VERSION
               value: "stable"
+          # ---------------------------
+          # VOLUME MOUNTING A DIRECTORY
+          # ---------------------------
+          volumeMounts:
+            - mountPath: /mnt/shared
+              name: my-volume
+              readOnly: true
+      volumes:
+        - name: my-volume
+        # mount /mnt/shared
+          hostPath:
+          # directory location on host, but only if that directory already exists
+            path: /mnt/shared
+            type: Directory
 ---
 {{- if .Values.istio.canary.enabled }}
 # Canary deployment


### PR DESCRIPTION
- Please look at our README.md file to test out the implementation (under "Using a Shared VirtualBox Folder to Create Shared Storage Across All Pods")
- All VMs mount the same shared VirtualBox folder as /mnt/shared into the VM.
- The deployed application mounts this path as a hostPath Volume into at least one Deployment . (in our case this is the stable version of app, you can look at "app-deployment.yaml")