### PR TITLE
A2 (Fix): Ansible provisioning through vagrant

### DIFF
--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -1,7 +1,8 @@
 ---
 # ansible/finalization.yml
 # Final cluster setup steps that require a fully functional cluster (Step 20+)
-# Run this after the cluster is initialized with:
+# This playbook is executed automatically via Vagrant provisioning.
+# But it could be execute manually using Ansible too:
 # ansible-playbook -u vagrant -i 192.168.56.100, finalization.yml
 
 - name: Finalize Kubernetes cluster setup


### PR DESCRIPTION
## Description
- Current configuration of `Vagrantfile` doesn't provision a few things (namely MetalLB, Kubernetes Dashboard config, and Istio) for the ctrl node
- Lack of provisioning can cause additional unnecessary installations onto the cluster afterwards or manual running of ansible-playbooks
- This PR aims to fix this issue by performing the provisioning for `finalization.yml` file in the `Vagrantfile`

## How to Test
- Run the following commands:
 ```bash
 vagrant up --no-provision
 vagrant provision
 ```
- This should result in a display of the following steps on the terminal to verify the execution of `finalization.yml` file:
  [Create temporary directory for MetalLB files]
  [Download MetalLB native manifest]
  [Apply MetalLB CRDs] 
  ...
  [Display Istio ingressgateway IP]